### PR TITLE
Added parameter to accept external rng functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Return a list of tuples `(state, probability)` sorted according the probability 
 >>> p.sort(reverse=True)
 [('C', 0.6), ('A', 0.3), ('B', 0.1)]
 ```
-#####**choose()**
+#####**choose(random_func=None)**
 Choose a state at random, according to its probability.
 ```python
 >>> p = pykov.Vector(A=.3, B=.7)
@@ -143,6 +143,15 @@ Choose a state at random, according to its probability.
 >>> p.choose()
 'A'
 ```
+
+Optionally, if you need to supply your own random number generator, you can pass a function that takes two inputs (the min and max) and Pykov will use that function.
+```python
+>>> def FakeRandom(min, max): return 0.01
+>>> p = pykov.Vector(A=.05, B=.4, C=.4, D=.15)
+>>> p.choose(FakeRandom)
+'A'        
+```
+
 
 #####**normalize()**
 Normalize the `pykov.Vector`, after normalization the probabilities sum to 1.
@@ -434,6 +443,13 @@ Do one step from the indicated `state` to one of its successors, chosen at rando
 >>> T = pykov.Chain({('A','B'): .3, ('A','A'): .7, ('B','A'): 1.})
 >>> T.move('A')
 'B'
+```
+
+Optionally, if you need to supply your own random number generator, you can pass a function that takes two inputs (the min and max) and Pykov will use that function.
+```python
+>>> def FakeRandom(min, max): return 0.01
+>>> T.move('A', FakeRandom)
+'B'        
 ```
 
 #####**walk(steps, start=None, stop=None)**

--- a/pykov.py
+++ b/pykov.py
@@ -281,19 +281,27 @@ class Vector(OrderedDict):
         for k in six.iterkeys(self):
             self[k] = self[k] / s
 
-    def choose(self):
+    def choose(self, random_func = None):
         """
-        Choose a state according to its probability.
+        Choose a state according to its probability. 
 
         >>> p = pykov.Vector(A=.3, B=.7)
         >>> p.choose()
         'B'
+        
+        Optionally, a function that generates a random number can be supplied.
+        >>> def FakeRandom(min, max): return 0.01
+        >>> p = pykov.Vector(A=.05, B=.4, C=.4, D=.15)
+        >>> p.choose(FakeRandom)
+        'A'        
 
         .. seealso::
 
            `Kevin Parks recipe <http://code.activestate.com/recipes/117241/>`_
         """
-        n = random.uniform(0, 1)
+        if random_func is None:
+           random_func = random.uniform 
+        n = random_func(0, 1)
         for state, prob in six.iteritems(self):
             if n < prob:
                 break
@@ -877,15 +885,21 @@ class Chain(Matrix):
     """
     """
 
-    def move(self, state):
+    def move(self, state, random_func = None):
         """
         Do one step from the indicated state, and return the final state.
 
         >>> T = pykov.Chain({('A','B'): .3, ('A','A'): .7, ('B','A'): 1.})
         >>> T.move('A')
         'B'
+
+        Optionally, a function that generates a random number can be supplied.
+        >>> def FakeRandom(min, max): return 0.01
+        >>> T.move('A', FakeRandom)
+        'B'        
+
         """
-        return self.succ(state).choose()
+        return self.succ(state).choose(random_func)
 
     def pow(self, p, n):
         """


### PR DESCRIPTION
Some simulations will need to use their own random number generator. These changes allow the user to supply their own RNG. 

Examples:

```python
>>> def FakeRandom(min, max): return 0.01
>>> p = pykov.Vector(A=.05, B=.4, C=.4, D=.15)
>>> p.choose(FakeRandom)
'A'        

>>> def FakeRandom(min, max): return 0.01
>>> T.move('A', FakeRandom)
'B'  
```