### PR TITLE
Allow Matrix to be pickled

### DIFF
--- a/pykov.py
+++ b/pykov.py
@@ -553,6 +553,11 @@ class Matrix(OrderedDict):
         """
         return Matrix(self)
 
+    def __reduce__(self):
+        """Return state information for pickling"""
+        # Required because we changed the OrderedDict.__init__ signature
+        return (self.__class__, (), None, None, six.iteritems(self))
+
     def _dok_(self, el2pos, method=''):
         """
         """


### PR DESCRIPTION
There were no tests in the project, otherwise I would have added some to demonstrate the need for this.

The problem with Matrix can be seen from this code:

    > python -c "import pickle; import pykov; print(pickle.loads(pickle.dumps(pykov.Matrix({('A', 'B'): 0.3}))))"
    
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/usr/lib/python2.7/pickle.py", line 1382, in loads
        return Unpickler(file).load()
      File "/usr/lib/python2.7/pickle.py", line 858, in load
        dispatch[key](self)
      File "/usr/lib/python2.7/pickle.py", line 1133, in load_reduce
        value = func(*args)
      File "/home/luke/devel/pykov/pykov.py", line 412, in __init__
        self.update([item for item in six.iteritems(data)
      File "/home/luke/.virtualenvs/learnscripture/local/lib/python2.7/site-packages/six.py", line 599, in iteritems
        return d.iteritems(**kw)
    AttributeError: 'list' object has no attribute 'iteritems'

The reason is that `Matrix` has altered the `OrderedDict.__init__` signature. `OrderedDict` expects an iterable of items, `Matrix` only allows a dictionary. Rather than complicate the signature, I added a `__reduce__` method to fix this.
