### PR TITLE
Allow for walks without steady states

### DIFF
--- a/pykov.py
+++ b/pykov.py
@@ -1080,7 +1080,13 @@ class Chain(Matrix):
         ['B', 'A', 'A', 'A', 'A', 'A', 'B']
         """
         if start is None:
-            start = self.steady().choose()
+            steady = self.steady()
+            if len(steady) != 0:
+                start = steady.choose()
+            else:
+                # There is no steady state, so choose a state uniformly at
+                # random.
+                start = random.sample(self.states(), 1)[0]
         if stop is None:
             result = [start]
             for i in range(steps):


### PR DESCRIPTION
This fixes the error in #20, handling the edge case of having no steady state. This seems like a pretty rare edge case for "usual" chains, as `Chain.steady()` usually returns something nonempty even if the chain isn't ergodic.

This also now selects a state uniformly at random if there is no steady state, which is more convenient than having users do it themselves. There might be better behavior to default to here, though.